### PR TITLE
Fix: make clean should clean up all compiled files

### DIFF
--- a/Makefile.board
+++ b/Makefile.board
@@ -118,7 +118,7 @@ size: $(RESULT).elf
 	@echo
 
 clean:
-	rm -f src/*.o src/*.d *.o *.d $(RESULT).elf $(RESULT).bin
+	rm -f src/*.o src/*.d *.o *.d *.lst src/hoptable.h peripheral_lib/src/*.o device/*.o device/*.d peripheral_lib/src/*.d peripheral_lib/eeprom_emulation/src/*.o peripheral_lib/eeprom_emulation/src/*.d $(RESULT).elf $(RESULT).bin
 
 debug: $(RESULT).elf
 	openocd -f /usr/share/openocd/scripts/interface/stlink-v2.cfg -f /usr/share/openocd/scripts/target/stm32f1x.cfg & echo $$! > $(OPENOCD_PIDFILE)


### PR DESCRIPTION
Remove a few extra files created during the compilation process